### PR TITLE
Allow user to specify movable.sed

### DIFF
--- a/src/include/libc.h
+++ b/src/include/libc.h
@@ -8,6 +8,7 @@
 
 void *memset(void * ptr, int value, size_t num);
 void *memcpy(void *destination, const void *source, size_t num);
+int memcmp(const void *a, const void *b, size_t num);
 //Returns number of digits
 //int u32tostr(u32 n, char *out);
 void wstr_to_str(const wchar_t *in, char *out);

--- a/src/source/libc.c
+++ b/src/source/libc.c
@@ -25,6 +25,18 @@ void *memcpy(void *destination, const void *source, size_t num)
     return destination;
 }
 
+int memcmp(const void *a, const void *b, size_t num)
+{
+    byte *_a = (byte*)a;
+    byte *_b = (byte*)b;
+	size_t i;
+	for(i = 0; i < num; i++) {
+		if(_a[i] != _b[i])
+			return 1;
+	}
+    return 0;
+}
+
 void wstr_to_str(const wchar_t *in, char *out)
 {
     wchar_t *w = (wchar_t *)in;


### PR DESCRIPTION
If movable.sed is on the root of the SD card when creating xorpads for
SD data, it will load the keyY from there.

Useful since we can now decrypt our NAND images (and by extension, our emuNAND images)
