### PR TITLE
Tweaks to verification

### DIFF
--- a/to3DS/CDNto3DS/CDNto3DS.py
+++ b/to3DS/CDNto3DS/CDNto3DS.py
@@ -4,11 +4,10 @@ import os
 import errno
 import sys
 import urllib2
-import hashlib
-import binascii
 from struct import unpack, pack
 from subprocess import call
 from binascii import hexlify
+from hashlib import sha256
 
 
 def mkdir_p(path):
@@ -67,6 +66,7 @@ forceDownload = 0
 forceDecrypt = 0
 make3ds = 1
 makecia = 1
+nohash = 0
 
 for i in xrange(len(sys.argv)) :
 	if sys.argv[i] == '-redown': forceDownload = 1
@@ -148,34 +148,56 @@ for i in xrange(contentCount):
 	cOffs = 0xB04+(0x30*i)
 	cID = format(unpack('>I', tmd[cOffs:cOffs+4])[0], '08x')
 	cIDX = format(unpack('>H', tmd[cOffs+4:cOffs+6])[0], '04x')
+	cSIZE = format(unpack('>Q', tmd[cOffs+8:cOffs+16])[0], 'd')
 	cHASH = format(unpack('>32s', tmd[cOffs+16:cOffs+48])[0])
 	if unpack('>H', tmd[cOffs+4:cOffs+6])[0] >= 8 :
 		make3ds = 0
 	
 	print 'Content ID:    ' + cID
 	print 'Content Index: ' + cIDX
-	print 'Content Hash:  ' + binascii.hexlify(cHASH)
+	print 'Content Size:  ' + cSIZE
+	print 'Content Hash:  ' + hexlify(cHASH)
 
 	outfname = titleid + '/' + cID
-	if os.path.exists(outfname) == 0 or forceDownload == 1:
+	if os.path.exists(outfname) == 0 or forceDownload == 1 or os.path.getsize(outfname) != unpack('>Q', tmd[cOffs+8:cOffs+16])[0]:
 		response = urllib2.urlopen(baseurl + '/' + cID)
 		chunk_read(response, outfname, report_hook=chunk_report)
-
-	if os.path.exists(outfname + '.dec') == 0 or forceDecrypt == 1:
+		
+		#If we redownloaded the content, then decrypting it is implied.
+		call(["aescbc", outfname, outfname + '.dec', titlekey, cIDX + '0000000000000000000000000000'])
+	
+	elif os.path.exists(outfname + '.dec') == 0 or forceDecrypt == 1 or os.path.getsize(outfname + '.dec') != unpack('>Q', tmd[cOffs+8:cOffs+16])[0]:
 		call(["aescbc", outfname, outfname + '.dec', titlekey, cIDX + '0000000000000000000000000000'])
 
 	with open(outfname + '.dec','rb') as fh:
-		hash = hashlib.sha256()
-		hash.update(fh.read())
+		fh.seek(0, os.SEEK_END)
+		fhSize = fh.tell()
+		if fh.tell() != unpack('>Q', tmd[cOffs+8:cOffs+16])[0]:
+			print 'Title size mismatch.  Download likely incomplete'
+			print 'Downloaded: ' + format(fh.tell(), 'd')
+			raise SystemExit(0)
+		fh.seek(0)
+		hash = sha256()
+		
+		while fh.tell() != fhSize:
+			hash.update(fh.read(0x1000000))
+			print 'checking hash: ' + format(float(fh.tell()*100)/fhSize,'.1f') + '% done\r',
+			
 		sha256file = hash.hexdigest()
-		if sha256file != binascii.hexlify(cHASH):
-			print 'Decryption failed. Wrong title key?'
+		if sha256file != hexlify(cHASH):
+			print 'hash mismatched, Decryption likely failed, wrong key?'
+			print 'got hash: ' + sha256file
 			raise SystemExit(0)
 		fh.seek(0x100)
 		if fh.read(4) != 'NCCH':
-			print 'Title is not an NCCH file container'
 			makecia = 0
 			make3ds = 0
+			fh.seek(0x60)
+			if fh.read(4) != 'WfA\0':
+				print 'Not NCCH, nor DSiWare, file likely corrupted'
+				raise SystemExit(0)
+			else:
+				print 'Not an NCCH container, likely DSiWare'
 		fh.seek(0, os.SEEK_END)
 		fSize += fh.tell()
 		


### PR DESCRIPTION
SHA256 verification now works with large files, instead of crashing with a memory error.
File size is now verified as well, to make sure the download was complete.

A rerun of the same command verifies the file size during the download phase, and if there is a mismatch, the file is redownloaded.  Also realized that decryption is implied if the file is downloaded, so added that into the download bit, then did an elif on the not downloading part.