### PR TITLE
Allow users to generate specific titles from SD card. Title IDs are placed after SD path and are then used to determine whether or not to add entries for each file.

### DIFF
--- a/SDinfo_gen.py
+++ b/SDinfo_gen.py
@@ -25,10 +25,26 @@ def parsedir(foldername, ctrlist):
 	except Exception as ex:
 		return
 
+	hastitlelist = False
+	if len(sys.argv) > 2:
+		titles = sys.argv[2:]
+		hastitlelist = True
+
 	for dirname, dirnames, filenames in os.walk('.'):
 		for filename in filenames:
 			if 'quota.dat' in filename.lower():
 				continue
+
+			#Only Generate titles requested
+			if hastitlelist:
+				shouldexit = True
+				for title in titles:
+					upper = title.lower()[:8]
+					lower = title.lower()[8:]
+					if dirname.startswith("./" + upper + "/" + lower):
+						shouldexit = False
+				if shouldexit:
+					continue
 
 			fsizeMB = roundUp(os.stat(os.path.join(dirname, filename)).st_size, 1024*1024) / (1024*1024)
 


### PR DESCRIPTION
Did this for personal use, figured it was a somewhat worthy addition to the main code. Basically you just take a title ID and add it as an argument for as many title IDs as you want to generate xorpads for. Makes it easier to decrypt specific apps or updates from an SD card. If it is desired, I could also add support for specific file paths (ie 00040000/000C6600/00000007.app) so that the file paths themselves could be checked (ie for updates vs the actual game itself).