### PR TITLE
Allow users to select specific versions when downloading from CDN

### DIFF
--- a/to3DS/CDNto3DS/CDNto3DS.py
+++ b/to3DS/CDNto3DS/CDNto3DS.py
@@ -97,8 +97,8 @@ except urllib2.URLError, e:
 
 tmd = tmd.read()
 
-mkdir_p(titleid)
-open(titleid + '/tmd','wb').write(tmd)
+mkdir_p(titleid + ('_v' + str(version), '')[version == -1])
+open(titleid + ('_v' + str(version), '')[version == -1] + '/tmd','wb').write(tmd)
 print 'Done\n'
 
 if tmd[:4] != '\x00\x01\x00\x04':
@@ -164,7 +164,7 @@ for i in xrange(contentCount):
 	print 'Content Size:  ' + cSIZE
 	print 'Content Hash:  ' + hexlify(cHASH)
 
-	outfname = titleid + '/' + cID
+	outfname = titleid + ('_v' + str(version), '')[version == -1] + '/' + cID
 	if os.path.exists(outfname) == 0 or forceDownload == 1 or os.path.getsize(outfname) != unpack('>Q', tmd[cOffs+8:cOffs+16])[0]:
 		response = urllib2.urlopen(baseurl + '/' + cID)
 		chunk_read(response, outfname, report_hook=chunk_report)

--- a/to3DS/CDNto3DS/CDNto3DS.py
+++ b/to3DS/CDNto3DS/CDNto3DS.py
@@ -68,7 +68,7 @@ forceDecrypt = 0
 make3ds = 1
 makecia = 1
 nohash = 0
-version = -1
+dlversion = -1
 
 for i in xrange(len(sys.argv)) :
 	if sys.argv[i] == '-redown': forceDownload = 1
@@ -77,7 +77,7 @@ for i in xrange(len(sys.argv)) :
 	elif sys.argv[i] == '-nocia': make3ds = 0
 	elif sys.argv[i] == '-vers': 
 		i += 1
-		version = sys.argv[i]
+		dlversion = sys.argv[i]
 	#else : SystemUsage()
 	
 if len(titleid) != 16 or len(titlekey) != 32:
@@ -89,15 +89,15 @@ baseurl = 'http://nus.cdn.c.shop.nintendowifi.net/ccs/download/' + titleid
 print 'Downloading TMD...'
 
 try:
-	tmd = urllib2.urlopen(baseurl + '/tmd' + ('.' + str(version), '')[version == -1])
+	tmd = urllib2.urlopen(baseurl + '/tmd' + ('.' + str(dlversion), '')[dlversion == -1])
 except urllib2.URLError, e:
 	print 'ERROR: Bad title ID?'
 	raise SystemExit(0)
 
 tmd = tmd.read()
 
-mkdir_p(titleid + ('_v' + str(version), '')[version == -1])
-open(titleid + ('_v' + str(version), '')[version == -1] + '/tmd','wb').write(tmd)
+mkdir_p(titleid + ('_v' + str(dlversion), '')[dlversion == -1])
+open(titleid + ('_v' + str(dlversion), '')[dlversion == -1] + '/tmd','wb').write(tmd)
 print 'Done\n'
 
 if tmd[:4] != '\x00\x01\x00\x04':
@@ -163,7 +163,7 @@ for i in xrange(contentCount):
 	print 'Content Size:  ' + cSIZE
 	print 'Content Hash:  ' + hexlify(cHASH)
 
-	outfname = titleid + ('_v' + str(version), '')[version == -1] + '/' + cID
+	outfname = titleid + ('_v' + str(dlversion), '')[dlversion == -1] + '/' + cID
 	if os.path.exists(outfname) == 0 or forceDownload == 1 or os.path.getsize(outfname) != unpack('>Q', tmd[cOffs+8:cOffs+16])[0]:
 		response = urllib2.urlopen(baseurl + '/' + cID)
 		chunk_read(response, outfname, report_hook=chunk_report)

--- a/to3DS/CDNto3DS/CDNto3DS.py
+++ b/to3DS/CDNto3DS/CDNto3DS.py
@@ -87,7 +87,6 @@ if len(titleid) != 16 or len(titlekey) != 32:
 baseurl = 'http://nus.cdn.c.shop.nintendowifi.net/ccs/download/' + titleid
 
 print 'Downloading TMD...'
-print baseurl + '/tmd' + ('.' + str(version), '')[version == -1]
 
 try:
 	tmd = urllib2.urlopen(baseurl + '/tmd' + ('.' + str(version), '')[version == -1])

--- a/to3DS/CDNto3DS/CDNto3DS.py
+++ b/to3DS/CDNto3DS/CDNto3DS.py
@@ -50,7 +50,8 @@ def chunk_read(response, outfname, chunk_size=2*1024*1024, report_hook=None):
 ##########
 
 def SystemUsage():
-	print 'Usage: CDNto3DS.py TitleID TitleKey [-redown -redec -no3ds -nocia]'
+	print 'Usage: CDNto3DS.py TitleID TitleKey [-vers -redown -redec -no3ds -nocia]'
+	print '-vers   : version of title to fetch'
 	print '-redown : redownload content'
 	print '-redec  : re-attempt content decryption'
 	print '-no3ds  : don\'t build 3DS file'
@@ -67,12 +68,16 @@ forceDecrypt = 0
 make3ds = 1
 makecia = 1
 nohash = 0
+version = -1
 
 for i in xrange(len(sys.argv)) :
 	if sys.argv[i] == '-redown': forceDownload = 1
 	elif sys.argv[i] == '-redec': forceDecrypt = 1
 	elif sys.argv[i] == '-no3ds': makecia = 0
 	elif sys.argv[i] == '-nocia': make3ds = 0
+	elif sys.argv[i] == '-vers': 
+		i += 1
+		version = sys.argv[i]
 	#else : SystemUsage()
 	
 if len(titleid) != 16 or len(titlekey) != 32:
@@ -82,9 +87,10 @@ if len(titleid) != 16 or len(titlekey) != 32:
 baseurl = 'http://nus.cdn.c.shop.nintendowifi.net/ccs/download/' + titleid
 
 print 'Downloading TMD...'
+print baseurl + '/tmd' + ('.' + str(version), '')[version == -1]
 
 try:
-	tmd = urllib2.urlopen(baseurl + '/tmd')
+	tmd = urllib2.urlopen(baseurl + '/tmd' + ('.' + str(version), '')[version == -1])
 except urllib2.URLError, e:
 	print 'ERROR: Bad title ID?'
 	raise SystemExit(0)


### PR DESCRIPTION
Added -vers argument, which allows users to download a specific tmd vs the latest one. Useful for pulling specific versions of an app or firm.