### PR TITLE
'printkeys.py' fix for 64-bit system

### DIFF
--- a/ticket-titlekey_stuff/printKeys.py
+++ b/ticket-titlekey_stuff/printKeys.py
@@ -3,8 +3,10 @@ import os
 from binascii import hexlify
 
 with open('decTitleKeys.bin', 'rb') as fh:
-	nEntries = struct.unpack('<I', fh.read(4))[0]
-	fh.seek(12, os.SEEK_CUR)
+	#struct.unpack would cause difference between 32 and 64 systems.
+	#nEntries = struct.unpack('<I', fh.read(4))[0]
+	nEntries = os.fstat(fh.fileno()).st_size / 32
+	fh.seek(16, os.SEEK_SET)
 	
 	for i in xrange(nEntries):
 		fh.seek(8, os.SEEK_CUR)


### PR DESCRIPTION
`struct.unpack` would cause difference between 32 and 64 systems.
So on my 64-bit system, int and long have the same size. And this cause a very big number for title keys count. Also this would avoid the error when all zero bytes for the starting 0-15.
Now it calculates the keys count by file size, to provide a proper count.
You could think this as a proper alternative for #12 where i didn't find the actual cause.